### PR TITLE
Add FitbitHRtoWS Support

### DIFF
--- a/HRCounter/Configuration/PluginConfig.cs
+++ b/HRCounter/Configuration/PluginConfig.cs
@@ -11,9 +11,11 @@ namespace HRCounter.Configuration
         // Must be 'virtual' if you want BSIPA to detect a value change and save the config automatically.
         public virtual bool LogHR { get; set; } = false;
 
-        public virtual string DataSource { get; set; } = "WebRequest";  // HypeRate or WebRequest
+        public virtual string DataSource { get; set; } = "WebRequest";  // HypeRate, WebRequest, or FitbitHRtoWS
 
         public virtual string HypeRateSessionID { get; set; } = "-1";
+
+        public virtual string FitbitWebSocket { get; set; } = "ws://localhost:8080/";
         
         public virtual string FeedLink { get; set; } = "NotSet";
 

--- a/HRCounter/Data/FitbitHRtoWS.cs
+++ b/HRCounter/Data/FitbitHRtoWS.cs
@@ -32,6 +32,7 @@ namespace HRCounter.Data
                 Stop();
             }
             webSocket = new WebSocket(_url);
+            webSocket.OnClose += WebSocket_OnClose;
             webSocket.OnMessage += WebSocket_OnMessage;
             webSocket.Connect();
             if (webSocket.IsAlive)
@@ -63,6 +64,11 @@ namespace HRCounter.Data
                     }
                 }
             }
+        }
+
+        private void WebSocket_OnClose(object sender, CloseEventArgs e)
+        {
+            _updating = false;
         }
 
         private void WebSocket_OnMessage(object sender, MessageEventArgs e)

--- a/HRCounter/Data/FitbitHRtoWS.cs
+++ b/HRCounter/Data/FitbitHRtoWS.cs
@@ -1,4 +1,4 @@
-﻿using HRCounter.Configuration;
+using HRCounter.Configuration;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using WebSocketSharp;
+using IPALogger = IPA.Logging.Logger;
 
 namespace HRCounter.Data
 {
@@ -33,8 +34,13 @@ namespace HRCounter.Data
             webSocket = new WebSocket(_url);
             webSocket.OnMessage += WebSocket_OnMessage;
             webSocket.Connect();
-            _updating = true;
-            SharedCoroutineStarter.instance.StartCoroutine(UpdateStuff());
+            if (webSocket.IsAlive)
+            {
+                _updating = true;
+                SharedCoroutineStarter.instance.StartCoroutine(UpdateStuff());
+            }
+            else
+                logger.Warn("Failed to connect to WebSocket. Is it running?");
         }
 
         protected override void RefreshSettings()

--- a/HRCounter/Data/FitbitHRtoWS.cs
+++ b/HRCounter/Data/FitbitHRtoWS.cs
@@ -1,0 +1,95 @@
+﻿using HRCounter.Configuration;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using WebSocketSharp;
+
+namespace HRCounter.Data
+{
+    internal sealed class FitbitHRtoWS : BpmDownloader
+    {
+        private WebSocket webSocket = null;
+        private string _url = string.Empty;
+        private bool _updating = false;
+
+        private bool _logHr = PluginConfig.Instance.LogHR;
+
+        private int lastHR = 0;
+        private bool isFitbitConnected = false;
+
+        internal FitbitHRtoWS() => RefreshSettings();
+
+        internal override void Start()
+        {
+            if(webSocket != null)
+            {
+                // WebSocket is listening. Stopping it then continue.
+                Stop();
+            }
+            webSocket = new WebSocket(_url);
+            webSocket.OnMessage += WebSocket_OnMessage;
+            webSocket.Connect();
+            _updating = true;
+            SharedCoroutineStarter.instance.StartCoroutine(UpdateStuff());
+        }
+
+        protected override void RefreshSettings()
+        {
+            _logHr = PluginConfig.Instance.LogHR;
+            _url = PluginConfig.Instance.FitbitWebSocket;
+        }
+
+        private IEnumerator UpdateStuff()
+        {
+            while (_updating)
+            {
+                if (webSocket != null)
+                {
+                    if (webSocket.IsAlive)
+                    {
+                        webSocket.Send("getHR");
+                        webSocket.Send("checkFitbitConnection");
+                        yield return new WaitForSeconds(1);
+                    }
+                }
+            }
+        }
+
+        private void WebSocket_OnMessage(object sender, MessageEventArgs e)
+        {
+            switch (e.Data)
+            {
+                case "yes":
+                    // This means the Fitbit is connected to the WebSocket
+                    // You are free to do whatever you want with this here if you want
+                    isFitbitConnected = true;
+                    break;
+                case "no":
+                    // This means the Fitbit is not connected to the WebSocket
+                    // You are free to do whatever you want with this here if you want
+                    isFitbitConnected = false;
+                    break;
+                default:
+                    // Assume it's the HeartRate
+                    try { lastHR = Convert.ToInt32(e.Data); } catch (Exception) { }
+                    break;
+            }
+            Bpm.Bpm = lastHR;
+        }
+
+        internal override void Stop()
+        {
+            if(webSocket != null)
+            {
+                if (webSocket.IsAlive)
+                    webSocket.Close();
+                webSocket = null;
+            }
+            _updating = false;
+        }
+    }
+}

--- a/HRCounter/HRCounter.cs
+++ b/HRCounter/HRCounter.cs
@@ -73,7 +73,16 @@ namespace HRCounter
 
                     _bpmDownloader = new HypeRate();
                     break;
-                
+
+                case "FitbitHRtoWS":
+                    if(PluginConfig.Instance.FitbitWebSocket == string.Empty)
+                    {
+                        _logger.Warn("FitbitWebSocket is empty.");
+                        return false;
+                    }
+                    _bpmDownloader = new FitbitHRtoWS();
+                    break;
+
                 default:
                     _bpmDownloader = null;
                     _logger.Warn("Unknown Data Sources");

--- a/HRCounter/HRCounter.csproj
+++ b/HRCounter/HRCounter.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Configuration\SettingController.cs" />
     <Compile Include="Data\BPM.cs" />
     <Compile Include="Data\BpmDownloader.cs" />
+    <Compile Include="Data\FitbitHRtoWS.cs" />
     <Compile Include="Data\HypeRate.cs" />
     <Compile Include="Data\WebRequest.cs" />
     <Compile Include="HRCounter.cs" />


### PR DESCRIPTION
First, let me start by saying this is the first ever PR I've ever done, so figuring out how to get to the point of 3 Files Changed took me hours.

Now let me get into the details of this PR. This PR adds full support for FitbitHRtoWS. If you've seen my previous fork, it was done in a very sloppy manner, hence why I didn't PR it. I made a new fork, starting over from scratch, and now I have made it so it integrates with your current system. I have already tested the changes in my own build, and it seemed to work perfectly fine. I haven't checked for console flooding, but that shouldn't be a problem. Attached below is my build, so if you'd like to test anything, please feel free to do so.

[HRCounter.zip](https://github.com/qe201020335/HRCounter/files/6796486/HRCounter.zip)

As for file changes:

+ `Config\PluginConfig.cs`
  + Added `FitbitWebSocket` (string)
    + Specifies the WebSocket URL that the client's FitbitHRtoWS Socket runs on.
    + This is just a normal String
  + Added `FitbitHRtoWS` property for `DataSource`
    + This is just the `DataSource` identifier.
    + Note that this will need to be Caps-Sensitive, since the switch-case in the `HRCounter.cs` doesn't ToLower() the string.
+ `Data\FitbitHRtoWS.cs`
  + The Data manager for FitbitHRtoWS
  + Derivative of `BpmDownloader`
+ `HRCounter.cs`
  + Added `"FitbitHRtoWS"` to switch-case
    + This is just for setting the `BpmDownloader` to `FitbitHRtoWS`

Some final notes:

I plan to re-write FitbitHRtoWS, but I plan to have backwards-compatibility for it. Once re-written, I'll probably try and get the FitbitHRtoWS app on the Fitbit Store, and maybe even have it call more data than just heartrate. 