### PR TITLE
Add support for v1.5.0 of FitbitHRtoWS

### DIFF
--- a/HRCounter/Data/FitbitHRtoWS.cs
+++ b/HRCounter/Data/FitbitHRtoWS.cs
@@ -67,7 +67,7 @@ namespace HRCounter.Data
                 while (_updating)
                 {
                     if (webSocket != null)
-                        if (webSocket.IsAlive)
+                        if (webSocket.ReadyState == WebSocketState.Open)
                         {
                             webSocket.Send("getHR");
                             webSocket.Send("checkFitbitConnection");
@@ -116,7 +116,7 @@ namespace HRCounter.Data
         {
             if(webSocket != null)
             {
-                if (webSocket.IsAlive)
+                if (webSocket.ReadyState == WebSocketState.Open)
                     webSocket.Close();
                 webSocket = null;
             }


### PR DESCRIPTION
v1.5.0 of FitbitHRtoWS adds support for a Public Server that runs over TLS 1.2. All the code does is check to see if the protocol is ws:// or wss:// and enable the SLL Protocol accordingly.