### PR TITLE
Custom HRProxy Data Source

### DIFF
--- a/HRCounter/Configuration/PluginConfig.cs
+++ b/HRCounter/Configuration/PluginConfig.cs
@@ -15,7 +15,7 @@ namespace HRCounter.Configuration
         public virtual bool ModEnable { get; set; } = true;
         public virtual bool LogHR { get; set; } = false;
 
-        public virtual string DataSource { get; set; } = "YUR MOD";  // HypeRate, Pulsoid, Pulsoid Token, WebRequest, YUR APP, FitbitHRtoWS, YUR MOD, Also Random for testing 
+        public virtual string DataSource { get; set; } = "YUR MOD";  // HypeRate, Pulsoid, Pulsoid Token, WebRequest, YUR APP, FitbitHRtoWS, HRProxy, YUR MOD, Also Random for testing 
 
         public virtual string PulsoidToken { get; set; } = "NotSet";
         
@@ -24,6 +24,8 @@ namespace HRCounter.Configuration
         public virtual string PulsoidWidgetID { get; set; } = "NotSet";
 
         public virtual string FitbitWebSocket { get; set; } = "ws://localhost:8080/";
+
+        public virtual string HRProxyID { get; set; } = "NotSet";
         
         public virtual string FeedLink { get; set; } = "NotSet";
 

--- a/HRCounter/Data/BpmDownloaders/HRProxy.cs
+++ b/HRCounter/Data/BpmDownloaders/HRProxy.cs
@@ -36,9 +36,13 @@ namespace HRCounter.Data.BpmDownloaders
             {
                 _id = Config.HypeRateSessionID;
             }
-            else
+            else if(_reader == "Pulsoid")
             {
                 _id = Config.PulsoidWidgetID;
+            }
+            else
+            {
+                _id = Config.HRProxyID;
             }
 
             JObject _subscribe = new JObject();

--- a/HRCounter/Installers/GameplayHeartRateInstaller.cs
+++ b/HRCounter/Installers/GameplayHeartRateInstaller.cs
@@ -70,6 +70,15 @@ namespace HRCounter.Installers
                     Container.Bind<BpmDownloader>().To<FitbitHRtoWS>().AsSingle();
                     break;
                 
+                case "HRProxy":
+                    if (Config.HRProxyID == "NotSet")
+                    {
+                        Logger.logger.Warn("HRProxy ID not set.");
+                        return;
+                    }
+                    Container.Bind<BpmDownloader>().To<HRProxy>().AsSingle();
+                    break;
+                
                 case "YUR APP":
                     Container.Bind<BpmDownloader>().To<YURApp>().AsSingle();
                     break;

--- a/HRCounter/Utils/DataSourceUtils.cs
+++ b/HRCounter/Utils/DataSourceUtils.cs
@@ -16,8 +16,8 @@ namespace HRCounter.Utils
         internal const string YUR_MOD_ID = "YUR Fit Calorie Tracker";
         internal const string WEBSOCKET_SHARP_MOD_ID = "websocket-sharp";
         internal const string PULSOID_API = "https://dev.pulsoid.net/api/v1/data/heart_rate/latest";
-        internal static readonly List<object> DataSources = new object[] {"HypeRate", "Pulsoid Token", "WebRequest", "FitbitHRtoWS", "Pulsoid", "YUR APP", "YUR MOD"}.ToList();
-        private static readonly List<string> DataSourcesRequireWebSocket = new [] {"HypeRate", "FitbitHRtoWS", "Pulsoid"}.ToList();
+        internal static readonly List<object> DataSources = new object[] {"HypeRate", "Pulsoid Token", "WebRequest", "FitbitHRtoWS", "HRProxy", "Pulsoid", "YUR APP", "YUR MOD"}.ToList();
+        private static readonly List<string> DataSourcesRequireWebSocket = new [] {"HypeRate", "FitbitHRtoWS", "Pulsoid", "HRProxy"}.ToList();
 
         internal static bool NeedWebSocket(string dc)
         {
@@ -56,6 +56,13 @@ namespace HRCounter.Utils
                         return $"<color=#FF0000>{WEBSOCKET_SHARP_MOD_ID} REQUIRED BUT NOT INSTALLED OR ENABLED!</color>";
                     }
                     return $"Current WebSocket Link: {ConditionalTruncate(PluginConfig.Instance.FitbitWebSocket, 30)}";
+                
+                case "HRProxy":
+                    if (!Utils.IsModEnabled(WEBSOCKET_SHARP_MOD_ID))
+                    {
+                        return $"<color=#FF0000>{WEBSOCKET_SHARP_MOD_ID} REQUIRED BUT NOT INSTALLED OR ENABLED!</color>";
+                    }
+                    return $"Current HRProxy ID: {ConditionalTruncate(PluginConfig.Instance.HRProxyID, 30)}";
                 
                 case "Pulsoid":
                     var s =


### PR DESCRIPTION
As mentioned in my Discord, I plan to remove the __***public***__ FitbitHRtoWS servers and switch them to HRProxy, a service which has already been integrated into HRCounter, to cut down on server costs. This PR changes the `HRProxy.cs` file to add support for the custom readers.

Can verify that this works when testing, here's a build to test for yourself if you'd like
[HRCounter.zip](https://github.com/qe201020335/HRCounter/files/10422901/HRCounter.zip)

Some things to verify before pulling:
+ `HRProxy.cs` line 39
  + Is this the correct deprecated Pulsoid DataSource?
+ Are there any missing user visuals for the HRProxy config?
  + I only added the DataSource and ID config values, which I believe was all